### PR TITLE
Add base Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+install:
+  - docker build -t quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} .
+
+script:
+  - "/bin/true"
+
+before_deploy:
+  - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
+
+deploy:
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: azavea/docker-spark
+      branch: develop
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: azavea/docker-spark
+      tags: true
+
+notifications:
+  slack:
+    secure: Jk/v0ZnbuTRVs7OpU7o8Kb3Nmgu9RgrofFXt1LbfMdkmn6WiSoLkAMXIpIyqLNNy8p7NKjC534MN8q7RCQmRED9qeneHFlblR8UPgQACXGdBPxDhpmUnPZadGx/GabbzAgksRqo1I8iBHL+LX6szAB8p87AEsXuocIkrff8M8MEAGdr6aHYEPeTKJ8BHgbVh9WpCcN6+TJ2/ijoZCs1bQGKzw/XTIo+Jyz+mMbw22sUmHUbN0ANBEZZTWBTpoljnwAnSjHm3M2rL2xmy1fpGm8SDMNIR7a3c5ASXl6mKVU8Yg/0i5bN6NqXJBmvqgujhKH4JXMBUV+BUxr/ASOr30yEGGHwfC7AKD21BQ4LmXrWCToLII228TKfo3dJ94FqTGw5QCQzbEmRCT5Zccm6nkL2IoyxjQxxeK+QIMlfbjMUSyfi3KvPbV6ShGwiSeBB2DAJ5xT4rBs8LvfjMDWUoZeLc6XmTVrNe4vlJmj7AQfaDcHf4gsbkqu4ZIZ1TfOwuIoZa9odxG9O46goT8QHmpR9gwmVy/m4R0xYtw5NnFpmMJ9ry/HnYy35C1M3ZHFSq1daq96/Zj1spMvZEq05JKWO/h07GZo12fmz4OsTMwHuxt1d+Ke1jLFDS7Y7QsgjJ1B5qu2iYXGYtca2xYpAmgoe5Y/9N68uzh5nNwkSwLxc=

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  QUAY_TAG="${TRAVIS_COMMIT:0:7}"
+else
+  QUAY_TAG="${TRAVIS_TAG}"
+
+  docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+fi
+
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"


### PR DESCRIPTION
Currently, Travis CI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `.travis.yml`.

More interesting is that Travis CI is setup to build and publish container images (to Quay) for all merges into `develop` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://quay.io/repository/azavea/spark
- https://travis-ci.org/azavea/docker-spark
