### PR TITLE
Bump Spark version to 1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/azavea/scala:0.1.0
 
 MAINTAINER Azavea <systems@azavea.com>
 
-ENV SPARK_VERSION 1.5.0
+ENV SPARK_VERSION 1.5.2
 ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR ${SPARK_HOME}/conf
 ENV PATH=${PATH}:${SPARK_HOME}/bin


### PR DESCRIPTION
That pretty much says it all.

Related to https://github.com/OpenTreeMap/otm-cloud/pull/99

---

**Testing**

Build the container image locally with:

``` bash
$ docker build -t quay.io/docker-spark:latest .
```

Attempt to run `spark-shell` inside of the new container image:

``` bash
$ docker run --rm quay.io/docker-spark:latest spark-shell "exit"
```
