### PR TITLE
Use azavea/scala:2.10.5 base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - docker build -t quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} .
 
 script:
-  - docker run quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} spark-shell "exit"
+  - docker run --rm quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} spark-shell
 
 before_deploy:
   - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/scala:0.1.0
+FROM quay.io/azavea/scala:2.10.5
 
 MAINTAINER Azavea <systems@azavea.com>
 


### PR DESCRIPTION
In an attempt to keep base images up-to-date, the `azavea/scala:2.10.5` tag will receive updates transparently vs. requiring changes to the `FROM quay.io/azavea/spark` line in the `Dockerfile` directly.

(2.10.5 here refers to a specific version of Scala.)
