### PR TITLE
Bump Spark version to 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/azavea/scala:2.10.5
 
 MAINTAINER Azavea <systems@azavea.com>
 
-ENV SPARK_VERSION 1.5.2
+ENV SPARK_VERSION 1.6.0
 ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR ${SPARK_HOME}/conf
 ENV PATH=${PATH}:${SPARK_HOME}/bin


### PR DESCRIPTION
See also: https://spark.apache.org/releases/spark-release-1-6-0.html
