### PR TITLE
Bump Spark version to 1.6.1; use Scala 2.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/azavea/scala:2.10.5
+FROM quay.io/azavea/scala:2.10.6
 
 MAINTAINER Azavea <systems@azavea.com>
 
-ENV SPARK_VERSION 1.6.0
+ENV SPARK_VERSION 1.6.1
 ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR ${SPARK_HOME}/conf
 ENV PATH=${PATH}:${SPARK_HOME}/bin


### PR DESCRIPTION
See also:
- http://www.scala-lang.org/news/2.10.6/
- https://spark.apache.org/releases/spark-release-1-6-1.html
