### PR TITLE
Bump Spark to 2.0.0; Hadoop to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jre
 
-ENV SPARK_VERSION 1.6.2
+ENV SPARK_VERSION 2.0.0
+ENV HADOOP_VERSION 2.7
 ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 
 RUN \
@@ -9,7 +10,7 @@ RUN \
                  --home /var/lib/spark --shell /usr/sbin/nologin \
                  spark \
       && mkdir -p /usr/lib/spark \
-      && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz \
+      && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       | tar -xzC /usr/lib/spark --strip-components=1 \
       && chown -R spark:spark /usr/lib/spark
 


### PR DESCRIPTION
Use Spark 2.0.0 as the default Spark distribution. Also, ensure that it is pre-built for Hadoop 2.7.

---

**Testing**

Execute the steps in the `README` to ensure that the Spark version was updated.
