### PR TITLE
Bump Spark to 2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-ENV SPARK_VERSION 2.0.1
+ENV SPARK_VERSION 2.0.2
 ENV HADOOP_VERSION 2.7
 ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 


### PR DESCRIPTION
Use Spark 2.0.2 as the default Spark distribution.

See: https://spark.apache.org/releases/spark-release-2-0-2.html

---

**Testing**

Execute the steps in the `README` to ensure that Spark 2.0.2 is being used:

```bash
❯ docker build -t quay.io/azavea/spark:latest .
❯ docker run -ti --rm quay.io/azavea/spark:latest spark-shell
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel).
16/11/22 15:08:26 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/11/22 15:08:27 WARN SparkContext: Use an existing SparkContext, some configuration may not take effect.
Spark context Web UI available at http://172.17.0.2:4040
Spark context available as 'sc' (master = local[*], app id = local-1479827307097).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.0.2
      /_/

Using Scala version 2.11.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_111)
Type in expressions to have them evaluated.
Type :help for more information.

scala>
```