### PR TITLE
Bump Spark to 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-ENV SPARK_VERSION 2.0.2
+ENV SPARK_VERSION 2.1.0
 ENV HADOOP_VERSION 2.7
 ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 


### PR DESCRIPTION
Use Spark 2.1.0 as the default Spark distribution.

See: https://spark.apache.org/releases/spark-release-2-1-0.html

---

**Testing**

Execute the steps in the `README` to ensure that Spark 2.0.2 is being used:

```bash
❯ docker build -t quay.io/azavea/spark:latest .
❯ docker run -ti --rm quay.io/azavea/spark:latest spark-shell
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
16/12/29 04:31:04 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/12/29 04:31:23 WARN ObjectStore: Version information not found in metastore. hive.metastore.schema.verification is not enabled so recording the schema version 1.2.0
16/12/29 04:31:23 WARN ObjectStore: Failed to get database default, returning NoSuchObjectException
16/12/29 04:31:25 WARN ObjectStore: Failed to get database global_temp, returning NoSuchObjectException
Spark context Web UI available at http://172.17.0.2:4040
Spark context available as 'sc' (master = local[*], app id = local-1482985866540).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.1.0
      /_/

Using Scala version 2.11.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_111)
Type in expressions to have them evaluated.
Type :help for more information.

scala>
```